### PR TITLE
Create a shell file to make training logs

### DIFF
--- a/codes/hyungsun/src/run_with_log.sh
+++ b/codes/hyungsun/src/run_with_log.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DATE=`python -c "from datetime import datetime; dt = datetime.now(); print('{}{}{}{}{}{}{}'.format(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond))"`
+FILE_NAME=log_$DATE.txt
+
+echo The result would be saved in src/logs/$FILE_NAME
+python -u $1 > ../logs/$FILE_NAME
+echo Finished


### PR DESCRIPTION
원래 텐서보드와 연동해서 트레이닝을 시키고 이를 관찰해야 하지만, 연구실 노드에서 돌렸을 때 텐서보드 url에 접근 가능한지가 불명확해서 임시로 트레이닝 결과를 로깅하기 위한 쉘 파일을 만들어보았습니다.

다음처럼 쓰시면 됩니다.
```
./run_with_log.sh train.py
```
The logs will be saved in src/logs/log_{datetime}.txt