### PR TITLE
CUDA 이슈 해결

### DIFF
--- a/src/config/config.ini
+++ b/src/config/config.ini
@@ -20,3 +20,4 @@ HIDDEN_SIZE = 100
 ; output is one of pos([1, 0]) and neg([0, 1]).
 OUTPUT_SIZE = 2
 BATCH_SIZE = 2
+MAX_EPOCH = 100

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -179,7 +179,6 @@ class Imdb(data.Dataset):
         """
         print("Processing...")
         words = self.embedding_model.wv.index2entity
-        words.insert(0, '-')
         word_to_idx = {words[i]: i for i in range(0, len(words))}
         training_set, test_set = None, None
         for mode in ['train', 'test']:
@@ -208,15 +207,15 @@ class Imdb(data.Dataset):
                                 except KeyError:
                                     # print('An excluded word:', alphabetic_word)
                                     pass
-                            vectors.append(torch.from_numpy(np.array(word_vectors, np.long)).type(torch.LongTensor))
+                            vectors.append(torch.from_numpy(np.array(word_vectors)).long())
 
             if mode == 'train':
                 training_set = (pad_sequence(vectors, batch_first=True),
-                                torch.from_numpy(np.array(grades, np.long)).type(torch.LongTensor))
+                                torch.from_numpy(np.array(grades)).long())
                 pass
             else:
                 training_set = (pad_sequence(vectors, batch_first=True),
-                                torch.from_numpy(np.array(grades, np.long)).type(torch.LongTensor))
+                                torch.from_numpy(np.array(grades)).long())
 
         processed_folder_full_path = os.path.join(self.root, self.processed_folder)
 

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -59,6 +59,7 @@ class Imdb(data.Dataset):
     vocab_file = 'imdb.vocab'
 
     # Constants for word embedding.
+    # TODO(sejin): Make it load the value from the ini file
     embedding_dimension = 100
 
     # Pre-trained embedding model for nn.Embedding.
@@ -206,15 +207,15 @@ class Imdb(data.Dataset):
                                 except KeyError:
                                     # print('An excluded word:', alphabetic_word)
                                     pass
-                            vectors.append(torch.from_numpy(np.array(word_vectors, np.long)))
+                            vectors.append(torch.from_numpy(np.array(word_vectors, np.long)).type(torch.LongTensor))
 
             if mode == 'train':
                 training_set = (pad_sequence(vectors, batch_first=True),
-                                torch.from_numpy(np.array(grades, np.long)))
+                                torch.from_numpy(np.array(grades, np.long)).type(torch.LongTensor))
                 pass
             else:
                 training_set = (pad_sequence(vectors, batch_first=True),
-                                torch.from_numpy(np.array(grades, np.long)))
+                                torch.from_numpy(np.array(grades, np.long)).type(torch.LongTensor))
 
         processed_folder_full_path = os.path.join(self.root, self.processed_folder)
 

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -179,6 +179,7 @@ class Imdb(data.Dataset):
         """
         print("Processing...")
         words = self.embedding_model.wv.index2entity
+        words.insert(0, '-')
         word_to_idx = {words[i]: i for i in range(0, len(words))}
         training_set, test_set = None, None
         for mode in ['train', 'test']:

--- a/src/model.py
+++ b/src/model.py
@@ -37,6 +37,8 @@ class RnnImdb(nn.Module):
         self.output_size = int(config["OUTPUT_SIZE"])  # output_size -> 2
         self.batch_size = int(config["BATCH_SIZE"])  # batch size -> 1
 
+        # TODO(sejin): Find a way to add a padding vector into word2vec object
+        pretrained = torch.cat((torch.FloatTensor([[0] * self.embed_size]), pretrained))
         self.embed = nn.Embedding.from_pretrained(pretrained)
         self.lstm = nn.LSTM(self.embed_size, self.hidden_size)
         self.linear = nn.Linear(self.hidden_size, self.output_size)

--- a/src/model.py
+++ b/src/model.py
@@ -32,6 +32,7 @@ class RnnImdb(nn.Module):
     def __init__(self, pretrained):
         super(RnnImdb, self).__init__()
         config = ConfigManager(self.__class__.__name__).load()
+        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.embed_size = int(config["EMBED_SIZE"])  # embed size -> 100
         self.hidden_size = int(config['HIDDEN_SIZE'])  # hidden_size -> 100
         self.output_size = int(config["OUTPUT_SIZE"])  # output_size -> 2
@@ -39,15 +40,23 @@ class RnnImdb(nn.Module):
 
         # TODO(sejin): Find a way to add a padding vector into word2vec object
         pretrained = torch.cat((torch.FloatTensor([[0] * self.embed_size]), pretrained))
-        self.embed = nn.Embedding.from_pretrained(pretrained)
-        self.lstm = nn.LSTM(self.embed_size, self.hidden_size)
-        self.linear = nn.Linear(self.hidden_size, self.output_size)
-        self.softmax = nn.LogSoftmax(dim=1)
+        if torch.cuda.is_available():
+            self.embed = nn.Embedding.from_pretrained(pretrained).cuda()
+            self.lstm = nn.LSTM(self.embed_size, self.hidden_size).cuda()
+            self.linear = nn.Linear(self.hidden_size, self.output_size).cuda()
+            self.softmax = nn.LogSoftmax(dim=1).cuda()
+        else:
+            self.embed = nn.Embedding.from_pretrained(pretrained)
+            self.lstm = nn.LSTM(self.embed_size, self.hidden_size)
+            self.linear = nn.Linear(self.hidden_size, self.output_size)
+            self.softmax = nn.LogSoftmax(dim=1)
 
     def forward(self, inputs):
         hidden, cell = self.init_hidden()
+        hidden, cell = hidden.to(device=self.device), cell.to(device=self.device)
         embed = torch.squeeze(self.embed(inputs), 2)
         out, (hidden, cell) = self.lstm(embed, (hidden, cell))
+
         linear = self.linear(out)
         output = self.softmax(linear[-1])
         return output, hidden, cell
@@ -56,5 +65,3 @@ class RnnImdb(nn.Module):
         hidden = Variable(torch.zeros(1, self.batch_size, self.hidden_size))
         cell = Variable(torch.zeros(1, self.batch_size, self.hidden_size))
         return hidden, cell
-
-

--- a/src/model.py
+++ b/src/model.py
@@ -38,8 +38,6 @@ class RnnImdb(nn.Module):
         self.output_size = int(config["OUTPUT_SIZE"])  # output_size -> 2
         self.batch_size = int(config["BATCH_SIZE"])  # batch size -> 1
 
-        # TODO(sejin): Find a way to add a padding vector into word2vec object
-        pretrained = torch.cat((torch.FloatTensor([[0] * self.embed_size]), pretrained))
         if torch.cuda.is_available():
             self.embed = nn.Embedding.from_pretrained(pretrained).cuda()
             self.lstm = nn.LSTM(self.embed_size, self.hidden_size).cuda()

--- a/src/train.py
+++ b/src/train.py
@@ -6,6 +6,7 @@ from model import *
 config = ConfigManager("RnnImdb").load()
 batch_size = int(config["BATCH_SIZE"])
 learning_rate = float(config["LEARNING_RATE"])
+max_epoch = int(config["MAX_EPOCH"])
 
 acl_imdb = ACLIMDB(batch_size=batch_size, word_embedding='CBOW', is_eval=False, test_mode=True)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -17,8 +18,7 @@ criterion = nn.NLLLoss()
 # TODO(yongha, sejin): Revive `Trainer` class.
 def main():
     print("Start training!!")
-    for i in range(100):
-        sum_loss = 0
+    for i in range(max_epoch):
         for batch_idx, (data, target) in enumerate(acl_imdb.load()):
             data, target = data.to(device=device), target.to(device=device)
             optimizer.zero_grad()
@@ -27,8 +27,7 @@ def main():
             loss = criterion(output, target)
             loss.backward()
             optimizer.step()
-            sum_loss += loss
-            print("epoch : ", i, "/", 99)
+            print("epoch : ", i + 1, "/", max_epoch)
             print("batch idx : ", batch_idx)
             print("loss : ", float(loss))
             print("target : ", target)

--- a/src/train.py
+++ b/src/train.py
@@ -6,28 +6,32 @@ from model import *
 config = ConfigManager("RnnImdb").load()
 batch_size = int(config["BATCH_SIZE"])
 acl_imdb = ACLIMDB(batch_size=batch_size, word_embedding='CBOW', is_eval=False, test_mode=True)
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 lstm = RnnImdb(torch.FloatTensor(acl_imdb.data.embedding_model.wv.vectors))
 optimizer = torch.optim.SGD(lstm.parameters(), lr=0.001, weight_decay=0.0003)
-criterian = nn.NLLLoss()
+criterion = nn.NLLLoss()
 
-
-# TODO(hyungsun): Revive `Trainer` class.
+# TODO(yongha, sejin): Revive `Trainer` class.
 def main():
     print("Start training!!")
-    for i in range(100):
+    for i in range(1000000):
         sum_loss = 0
-        # TODO(hyungsun): Consider `CUDA` while training.
         for batch_idx, (data, target) in enumerate(acl_imdb.load()):
+            data, target = data.to(device=device), target.to(device=device)
             optimizer.zero_grad()
             input_data = data.view(-1, batch_size, 1)
             output, hidden, cell = lstm(input_data)
-            loss = criterian(output, target)
+            loss = criterion(output, target)
             loss.backward()
             optimizer.step()
             sum_loss += loss
-            print("loss : ", float(loss * 100))
-
+            print("epoch : ", i, "/", 999999)
+            print("batch idx : ", batch_idx)
+            print("loss : ", float(loss))
+            print("target : ", target)
+            print("output : ", output)
+            print()
 
 if __name__ == "__main__":
     main()

--- a/src/train.py
+++ b/src/train.py
@@ -5,17 +5,19 @@ from model import *
 
 config = ConfigManager("RnnImdb").load()
 batch_size = int(config["BATCH_SIZE"])
+learning_rate = float(config["LEARNING_RATE"])
+
 acl_imdb = ACLIMDB(batch_size=batch_size, word_embedding='CBOW', is_eval=False, test_mode=True)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 lstm = RnnImdb(torch.FloatTensor(acl_imdb.data.embedding_model.wv.vectors))
-optimizer = torch.optim.SGD(lstm.parameters(), lr=0.001, weight_decay=0.0003)
+optimizer = torch.optim.SGD(lstm.parameters(), lr=learning_rate, weight_decay=0.0003)
 criterion = nn.NLLLoss()
 
 # TODO(yongha, sejin): Revive `Trainer` class.
 def main():
     print("Start training!!")
-    for i in range(1000000):
+    for i in range(100):
         sum_loss = 0
         for batch_idx, (data, target) in enumerate(acl_imdb.load()):
             data, target = data.to(device=device), target.to(device=device)
@@ -26,7 +28,7 @@ def main():
             loss.backward()
             optimizer.step()
             sum_loss += loss
-            print("epoch : ", i, "/", 999999)
+            print("epoch : ", i, "/", 99)
             print("batch idx : ", batch_idx)
             print("loss : ", float(loss))
             print("target : ", target)


### PR DESCRIPTION
커밋이 총 3개입니다.
1. `np.array`를 tensor로 변환하면 `dtype`을 뭘로 주든 간에 윈도우 운영체제에서는 `IntTensor`로 생성되는 자잘한 문제가 있었습니다.
2. 패딩을 모두 0으로 주면서 0번 인덱스 단어벡터를 가져오는 문제가 있었는데 0번 인덱스 단어벡터에 `torch.FloatTensor([0 *100])`를 집어넣어 해결했습니다. 다만, 임베딩을 처리하는 쪽이 아닌 모델 쪽에서 패딩 벡터를 추가하는 임시방편 형태라 리팩토링이 필요합니다.
3. 이제 학습할 때 CUDA를 쓸 수 있습니다.
---
수정내역 2번은 이 PR에서 제외시켰습니다.